### PR TITLE
Fix output for multiple geothermal gradients

### DIFF
--- a/src/geophires_x/Outputs.py
+++ b/src/geophires_x/Outputs.py
@@ -159,9 +159,9 @@ class Outputs:
                     f.write(f"      Geothermal gradient:                                {model.reserv.gradient.value[0]:10.4f} " + model.reserv.gradient.CurrentUnits.value + NL)
                 else:
                     for i in range(1, model.reserv.numseg.value):
-                        f.write(f"      Segment {str(i):s}   Geothermal gradient:                      {model.reserv.gradient.value[i-1]:10.4f} " + model.reserv.gradient.CurrentUnits.value +NL)
-                        f.write(f"      Segment {str(i):s}   Thickness (km):                           {model.reserv.layerthickness.value[i-1]:10.0f} " + model.reserv.layerthickness.CurrentUnits.value + NL)
-                        f.write(f"      Segment {str(i+1):s} Geothermal gradient:                      {model.reserv.gradient.value[i]:10.4f} " + model.reserv.gradient.CurrentUnits.value + NL)
+                        f.write(f"      Segment {str(i):s}   Geothermal gradient:                    {model.reserv.gradient.value[i-1]:10.4f} " + model.reserv.gradient.CurrentUnits.value +NL)
+                        f.write(f"      Segment {str(i):s}   Thickness:                         {model.reserv.layerthickness.value[i-1]:10.0f} " + model.reserv.layerthickness.CurrentUnits.value + NL)
+                    f.write(f"      Segment {str(i+1):s}   Geothermal gradient:                    {model.reserv.gradient.value[i]:10.4f} " + model.reserv.gradient.CurrentUnits.value + NL)
 
                 f.write(NL)
                 f.write(NL)
@@ -214,9 +214,11 @@ class Outputs:
                     f.write(f"      Geothermal gradient:                                {model.reserv.gradient.value[0]:10.4f} " + model.reserv.gradient.CurrentUnits.value + NL)
                 else:
                     for i in range(1, model.reserv.numseg.value):
-                        f.write(f"      Segment " + str(i) + " geothermal gradient:                   {model.reserv.gradient.value[i-1]:10.4f} " + model.reserv.gradient.CurrentUnits.value + NL)
-                        f.write(f"      Segment " + str(i) + " thickness:                           {model.reserv.layerthickness.value[i-1]:10.0f} " + model.reserv.layerthickness.CurrentUnits.value + NL)
-                        f.write(f"      Segment " + str(i+1) + " geothermal gradient:                   {model.reserv.gradient.value[i]:10.4f} " + model.reserv.gradient.CurrentUnits.value + NL)
+                        f.write(f"      Segment {str(i):s}   Geothermal gradient:                    {model.reserv.gradient.value[i-1]:10.4f} " + model.reserv.gradient.CurrentUnits.value +NL)
+                        f.write(f"      Segment {str(i):s}   Thickness:                         {model.reserv.layerthickness.value[i-1]:10.0f} " + model.reserv.layerthickness.CurrentUnits.value + NL)
+                    f.write(f"      Segment {str(i+1):s}   Geothermal gradient:                    {model.reserv.gradient.value[i]:10.4f} " + model.reserv.gradient.CurrentUnits.value + NL)
+
+
 
                 f.write(NL)
                 f.write(NL)


### PR DESCRIPTION
Fixes how multiple gradients are displayed in the output file. Fix is required prior to addressing https://github.com/NREL/python-geophires-x/issues/38

@softwareengineerprogrammer  please take a look at the attached example file for multiple gradients (example_multiple_gradientsOUT.txt should be renamed to example_multiple_gradients.out). Adding these as a unit test caused an error I believe due to Segment now having a number in the output file? (i.e., Segment 1 geothermal gradient, ... Segment 2 geothermal gradient, ... etc.). This unit test addresses https://github.com/NREL/python-geophires-x/issues/38
[example_multiple_gradients.txt](https://github.com/NREL/python-geophires-x/files/13326423/example_multiple_gradients.txt)
[example_multiple_gradientsOUT.txt](https://github.com/NREL/python-geophires-x/files/13326424/example_multiple_gradientsOUT.txt)

![image](https://github.com/NREL/python-geophires-x/assets/38221976/19b23c1e-4c36-459c-9ca3-cf89c4b9d1e1)
