### PR TITLE
Fixes example 12, includes missing default values and fixes bugs

### DIFF
--- a/src/geophires_x/Economics.py
+++ b/src/geophires_x/Economics.py
@@ -231,7 +231,7 @@ def CalculateLCOELCOH(self, model: Model) -> tuple:
                 (self.Coam.value + model.surfaceplant.PumpingkWh.value * model.surfaceplant.elecprice.value / 1E6 + \
                  self.annualngcost.value) * discountvector)) / np.sum(
                 model.surfaceplant.annualheatingdemand.value * discountvector) * 1E2  # cents/kWh
-            LCOH = self.LCOH.value * 2.931  # $/Million Btu
+            LCOH = LCOH * 2.931  # $/Million Btu
 
     elif self.econmodel.value == EconomicModel.BICYCLE:
         iave = self.FIB.value * self.BIR.value * (1 - self.CTR.value) + (
@@ -809,6 +809,7 @@ class Economics:
         self.chillercapex = self.ParameterDict[self.chillercapex.Name] = floatParameter(
             "Absorption Chiller Capital Cost",
             value=-1.0,
+            DefaultValue=5,
             Min=0,
             Max=100,
             UnitType=Units.CURRENCY,
@@ -821,6 +822,7 @@ class Economics:
         self.chilleropex = self.ParameterDict[self.chilleropex.Name] = floatParameter(
             "Absorption Chiller O&M Cost",
             value=-1.0,
+            DefaultValue=1,
             Min=0,
             Max=100,
             UnitType=Units.CURRENCYFREQUENCY,
@@ -835,6 +837,7 @@ class Economics:
         self.heatpumpcapex = self.ParameterDict[self.heatpumpcapex.Name] = floatParameter(
             "Heat Pump Capital Cost",
             value=-1.0,
+            DefaultValue=5,
             Min=0,
             Max=100,
             UnitType=Units.CURRENCY,
@@ -849,6 +852,7 @@ class Economics:
         self.ngprice = self.ParameterDict[self.ngprice.Name] = floatParameter(
             "Peaking Fuel Cost Rate",
             value=0.034,
+            DefaultValue =0.034,
             Min=0.0,
             Max=1.0,
             UnitType=Units.ENERGYCOST,
@@ -860,6 +864,7 @@ class Economics:
         self.peakingboilerefficiency = self.ParameterDict[self.peakingboilerefficiency.Name] = floatParameter(
             "Peaking Boiler Efficiency",
             value=0.85,
+            DefaultValue = 0.85,
             Min=0,
             Max=1,
             UnitType=Units.PERCENT,
@@ -873,6 +878,7 @@ class Economics:
         self.dhpipingcostrate = self.ParameterDict[self.dhpipingcostrate.Name] = floatParameter(
             "District Heating Piping Cost Rate",
             value=1200,
+            DefaultValue=1200,
             Min=0,
             Max=10000,
             UnitType=Units.COSTPERDISTANCE,
@@ -886,6 +892,7 @@ class Economics:
         self.dhtotaldistrictnetworkcost = self.ParameterDict[self.dhtotaldistrictnetworkcost.Name] = floatParameter(
             "Total District Heating Network Cost",
             value=10,
+            DefaultValue=10,
             Min=0,
             Max=1000,
             UnitType=Units.CURRENCY,
@@ -899,6 +906,7 @@ class Economics:
         self.dhoandmcost = self.ParameterDict[self.dhoandmcost.Name] = floatParameter(
             "District Heating O&M Cost",
             value=1,
+            DefaultValue=1,
             Min=0,
             Max=100,
             UnitType=Units.CURRENCYFREQUENCY,
@@ -910,6 +918,7 @@ class Economics:
         self.dhpipinglength = self.ParameterDict[self.dhpipinglength.Name] = floatParameter(
             "District Heating Network Piping Length",
             value=10.0,
+            DefaultValue = 10.0,
             Min=0,
             Max=1000,
             UnitType=Units.LENGTH,
@@ -921,6 +930,7 @@ class Economics:
         self.dhroadlength = self.ParameterDict[self.dhroadlength.Name] = floatParameter(
             "District Heating Road Length",
             value=10.0,
+            DefaultValue = 10.0,
             Min=0,
             Max=1000,
             UnitType=Units.LENGTH,
@@ -932,6 +942,7 @@ class Economics:
         self.dhlandarea = self.ParameterDict[self.dhlandarea.Name] = floatParameter(
             "District Heating Land Area",
             value=10.0,
+            DefaultValue=10.0,
             Min=0,
             Max=1000,
             UnitType=Units.AREA,
@@ -943,6 +954,7 @@ class Economics:
         self.dhpopulation = self.ParameterDict[self.dhpopulation.Name] = floatParameter(
             "District Heating Population",
             value=200,
+            DefaultValue=200,
             Min=0,
             Max=1000000,
             UnitType=Units.NONE,

--- a/src/geophires_x/Parameter.py
+++ b/src/geophires_x/Parameter.py
@@ -257,6 +257,7 @@ def ReadParameter(ParameterReadIn: ParameterEntry, ParamToModify, model):
         New_val = float(ParameterReadIn.sValue)
         # Warning - the value read in is the same as the default value, making it superfluous - add a warning and suggestion
         if New_val == ParamToModify.DefaultValue:
+            ParamToModify.Provided = True
             if len(ParamToModify.ErrMessage) > 0:
                 print("Warning: Parameter given (" + str(New_val) + ") for " + ParamToModify.Name +
                       " is being set by the input file to a value that is the same as the default. No change was" +
@@ -283,7 +284,7 @@ def ReadParameter(ParameterReadIn: ParameterEntry, ParamToModify, model):
         else:  # All is good
             ParamToModify.value = New_val  # set the new value
             ParamToModify.Provided = True  # set provided to true because we are using a user provide value now
-            ParamToModify.Valid = True  # set Valid to true because it passed the validation tests
+            ParamToModify.Valid = True   # set Valid to true because it passed the validation tests
     elif isinstance(ParamToModify, listParameter):
         New_val = float(ParameterReadIn.sValue)
         if (New_val < float(ParamToModify.Min)) or (New_val > float(ParamToModify.Max)):

--- a/tests/examples/example12_DH.out
+++ b/tests/examples/example12_DH.out
@@ -6,9 +6,9 @@ Simulation Metadata
 ----------------------
  GEOPHIRES Version: 3.0
  GEOPHIRES Build Date: 2022-06-30
- Simulation Date: 2023-11-13
- Simulation Time:  13:41
- Calculation Time:      0.172 sec
+ Simulation Date: 2023-11-16
+ Simulation Time:  18:22
+ Calculation Time:      0.105 sec
 
                            ***SUMMARY OF RESULTS***
 
@@ -17,7 +17,7 @@ Simulation Metadata
       Average Annual Geothermal Heat Production:            148.48 GWh/year
       Average Annual Peaking Fuel Heat Production:           94.42 GWh/year
       Average Direct-Use Heat Production:                    19.90 MW
-      Direct-Use heat breakeven price:                        0.00 USD/MMBTU
+      Direct-Use heat breakeven price:                        8.68 USD/MMBTU
       Number of production wells:                             2
       Number of injection wells:                              2
       Flowrate per production well:                          50.0 kg/sec
@@ -99,10 +99,10 @@ Simulation Metadata
          Surface power plant costs:                          12.40 MUSD
             of which Peaking Boiler Cost:                     3.99 MUSD
          Field gathering system costs:                        2.53 MUSD
-         District Heating System Cost:                        4.80 MUSD
+         District Heating System Cost:                        2.70 MUSD
          Total surface equipment costs:                      14.93 MUSD
          Exploration costs:                                   0.00 MUSD
-      Total capital costs:                                   48.02 MUSD
+      Total capital costs:                                   45.92 MUSD
 
 
                 ***OPERATING AND MAINTENANCE COSTS (M$/yr)***
@@ -111,9 +111,9 @@ Simulation Metadata
          Power plant maintenance costs:                       0.74 MUSD/yr
          Water costs:                                         0.00 MUSD/yr
          Average Reservoir Pumping Cost:                      0.21 MUSD/yr
-         Annual District Heating O&M Cost:                    0.39 MUSD/yr
+         Annual District Heating O&M Cost:                    0.37 MUSD/yr
          Average Annual Peaking Fuel Cost:                    3.03 MUSD/yr
-      Total operating and maintenance costs:                  1.82 MUSD/yr
+      Total operating and maintenance costs:                  1.80 MUSD/yr
 
 
                            ***SURFACE EQUIPMENT SIMULATION RESULTS***

--- a/tests/examples/example12_DH.txt
+++ b/tests/examples/example12_DH.txt
@@ -56,30 +56,16 @@ Surface Temperature,12,			--- [deg.C]
 Ambient Temperature,12,			--- [deg.C]
 End-Use Efficiency Factor,0.8,		--- [-]
 
-
-***District Heating System (If end-use option 8 selected)*
 District Heating Demand Option,1,					--- Should be 1 or 2. See manual or below for option details
-
-*Option 1: Known Heat Demand Profile***
 District Heating Demand File Name,Examples/cornell_heat_demand.csv,		--- hourly MW thermal demand in a CSV file
 District Heating Demand Data Time Resolution,1,				--- 1 for hourly, 2 for daily
 District Heating Demand Data Column Number,2,				---
 
-**District Heating Capital and O&M Parameters (If end use option 6 selected)*
 Peaking Fuel Cost Rate,0.0273, 					--- [$/kWh] Cost of natural gas for peak boiler use
 Peaking Boiler Efficiency,0.85,			`		--- Should be between 0 and 1, defaults to 0.85
 District Heating Piping Cost Rate,1200,					--- [$/m] used for calculating surface piping capital cost for district heat
-Total District Heating Network Cos,10, 					--- [M$] supersedes options 1 and 2 if any value is entered
-District Heating O&M Cos,2, 				--- [M$/year] supersedes options 1 and 2 if any value is entered
+District Heating Road Length,3, 				---[km] supersedes model option 2 if any value is entered
 
-District Cost Models
-*Option 1**
-District Heating Network Piping Lengt,7.66, 					---[km] supersedes road length or model option 2 if any value is entered
-District Heating Road Lengt,3, 				---[km] supersedes model option 2 if any value is entered
-
-*Option 2**
-District Heating Land Area,4, 						---[km^2]
-District Heating Population,240, 						---[persons] Optional if a number of household was provided
 
 *** Economic/Financial Parameters ***
 *************************************


### PR DESCRIPTION
Several bugs fixed:

- Example 12 had incorrect input parameters (addresses issue https://github.com/NREL/python-geophires-x/issues/56)
- Economics LCOH calculation for standard levelized cost model for district heating as end-use had bug causing LCOH to be 0.
- There were missing default values in the economics class.
- When user provides parameter that matches the default parameter, GEOPHIRES did not flag this as a user-provided parameter. This was required for the district heating economics module to work properly.