### PR TITLE
Fixes bugs and adds example13.txt as new unit test

### DIFF
--- a/src/geophires_x/Economics.py
+++ b/src/geophires_x/Economics.py
@@ -209,7 +209,7 @@ def CalculateLCOELCOH(self, model: Model) -> tuple:
             elif model.surfaceplant.enduseoption.value in [EndUseOptions.COGENERATION_TOPPING_EXTRA_ELECTRICTY,
                                                            EndUseOptions.COGENERATION_BOTTOMING_EXTRA_ELECTRICTY,
                                                            EndUseOptions.COGENERATION_PARALLEL_EXTRA_ELECTRICTY]:  # electricity sales is additional income revenue stream
-                annualelectricityincome = model.surfaceplant.NetkWhProduced.value * self.elecprice.value / 1E6  # M$/year
+                annualelectricityincome = model.surfaceplant.NetkWhProduced.value * model.surfaceplant.elecprice.value / 1E6  # M$/year
                 LCOH = ((1 + self.inflrateconstruction.value) * self.CCap.value + np.sum(
                     (self.Coam.value - annualelectricityincome) * discountvector)) / np.sum(
                     model.surfaceplant.HeatkWhProduced.value * discountvector) * 1E8  # cents/kWh
@@ -2080,7 +2080,7 @@ class Economics:
                     model.surfaceplant.HeatProduced.value / model.surfaceplant.enduseefficiencyfactor.value) * 1000.
             elif model.surfaceplant.enduseoption.value in [EndUseOptions.COGENERATION_BOTTOMING_EXTRA_HEAT,
                                                            EndUseOptions.COGENERATION_BOTTOMING_EXTRA_ELECTRICTY]:  # enduseoption = 4: cogen bottoming cycle
-                self.Cplant = self.Cplant.value + 1.12 * 1.15 * self.ccplantadjfactor.value * 250E-6 * np.max(
+                self.Cplant.value = self.Cplant.value + 1.12 * 1.15 * self.ccplantadjfactor.value * 250E-6 * np.max(
                     model.surfaceplant.HeatProduced.value / model.surfaceplant.enduseefficiencyfactor.value) * 1000.
             elif model.surfaceplant.enduseoption.value in [EndUseOptions.COGENERATION_PARALLEL_EXTRA_ELECTRICTY,
                                                            EndUseOptions.COGENERATION_PARALLEL_EXTRA_HEAT]:  # cogen parallel cycle

--- a/src/geophires_x/OptionList.py
+++ b/src/geophires_x/OptionList.py
@@ -7,8 +7,8 @@ class EndUseOptions(str, Enum):
     HEAT = "Direct-Use Heat"  # 2
     COGENERATION_TOPPING_EXTRA_HEAT = "Cogeneration Topping Cycle, Heat sales considered as extra income"  # 31
     COGENERATION_TOPPING_EXTRA_ELECTRICTY = "Cogeneration Topping Cycle, Electricity sales considered as extra income"  # 32
-    COGENERATION_BOTTOMING_EXTRA_ELECTRICTY = "Cogeneration Bottoming Cycle, Electricity sales considered as extra income"  # 41
-    COGENERATION_BOTTOMING_EXTRA_HEAT = "Cogeneration Bottoming Cycle, Heat sales considered as extra income"  # 42
+    COGENERATION_BOTTOMING_EXTRA_HEAT = "Cogeneration Bottoming Cycle, Heat sales considered as extra income"  # 41
+    COGENERATION_BOTTOMING_EXTRA_ELECTRICTY = "Cogeneration Bottoming Cycle, Electricity sales considered as extra income"  # 42
     COGENERATION_PARALLEL_EXTRA_HEAT = "Cogeneration Parallel Cycle, Heat sales considered as extra income"  # 51
     COGENERATION_PARALLEL_EXTRA_ELECTRICTY = "Cogeneration Parallel Cycle, Electricity sales considered as extra income"  # 52
     ABSORPTION_CHILLER = "Absorption Chiller"  # 6

--- a/src/geophires_x/SurfacePlant.py
+++ b/src/geophires_x/SurfacePlant.py
@@ -686,7 +686,7 @@ class SurfacePlant:
 
         else:
             if self.enduseoption.value in [EndUseOptions.COGENERATION_BOTTOMING_EXTRA_ELECTRICTY, EndUseOptions.COGENERATION_BOTTOMING_EXTRA_HEAT]:
-                self.TenteringPP.value = self.Tchpbottom.value
+                self.TenteringPP.value = self.Tchpbottom.value*np.ones(len(model.reserv.timevector.value))
             else:
                 self.TenteringPP.value = model.wellbores.ProducedTemperature.value
             # Availability water (copied from GEOPHIRES v1.0 Fortran Code)
@@ -886,8 +886,8 @@ class SurfacePlant:
                 self.ElectricityProduced.value = self.Availability.value*etau*model.wellbores.nprod.value*model.wellbores.prodwellflowrate.value
                 self.HeatExtracted.value = model.wellbores.nprod.value*model.wellbores.prodwellflowrate.value*model.reserv.cpwater.value *\
                                            (model.wellbores.ProducedTemperature.value - model.wellbores.Tinj.value)/1E6  # Heat extracted from geofluid [MWth]
-                self.valueHeatProduced.value = self.enduseefficiencyfactor.value*model.wellbores.nprod.value *\
-                                               model.wellbores.prodwellflowrate*model.reserv.cpwater.value *\
+                self.HeatProduced.value = self.enduseefficiencyfactor.value*model.wellbores.nprod.value *\
+                                               model.wellbores.prodwellflowrate.value*model.reserv.cpwater.value *\
                                                (model.wellbores.ProducedTemperature.value - self.Tchpbottom.value)/1E6  # Useful heat for direct-use application [MWth]
                 HeatExtractedTowardsElectricity = model.wellbores.nprod.value*model.wellbores.prodwellflowrate.value *\
                                                   model.reserv.cpwater.value*(self.Tchpbottom.value - model.wellbores.Tinj.value)/1E6

--- a/src/geophires_x/WellBores.py
+++ b/src/geophires_x/WellBores.py
@@ -978,6 +978,9 @@ class WellBores:
                 ProducedTemperatureRepeatead = np.tile(self.ProducedTemperature.value[0:indexfirstmaxdrawdown],
                                                        self.redrill.value + 1)
                 self.ProducedTemperature.value = ProducedTemperatureRepeatead[0:len(self.ProducedTemperature.value)]
+                TResOutputRepeated = np.tile(model.reserv.Tresoutput.value[0:indexfirstmaxdrawdown],
+                                                       self.redrill.value + 1)
+                model.reserv.Tresoutput.value = TResOutputRepeated[0:len(self.ProducedTemperature.value)]
 
         # calculate pressure drops and pumping power
         self.DPProdWell.value, f3, vprod, self.rhowaterprod = WellPressureDrop(

--- a/tests/examples/example13.out
+++ b/tests/examples/example13.out
@@ -1,0 +1,207 @@
+                               *****************
+                               ***CASE REPORT***
+                               *****************
+
+Simulation Metadata
+----------------------
+ GEOPHIRES Version: 3.0
+ GEOPHIRES Build Date: 2022-06-30
+ Simulation Date: 2023-11-20
+ Simulation Time:  16:41
+ Calculation Time:      0.047 sec
+
+                           ***SUMMARY OF RESULTS***
+
+      End-Use Option: Cogeneration Bottoming Cycle, Electricity sales considered as extra income
+      Average Net Electricity Production:                     3.16 MW
+      Average Direct-Use Heat Production:                    15.98 MW
+      Direct-Use heat breakeven price:                       13.01 USD/MMBTU
+      Number of production wells:                             2
+      Number of injection wells:                              2
+      Flowrate per production well:                          50.0 kg/sec
+      Well depth (or total length, if not vertical):          4.0 kilometer
+      Geothermal gradient:                                    0.0500 degC/m
+
+
+                           ***ECONOMIC PARAMETERS***
+
+      Economic Model = Standard Levelized Cost
+      Interest Rate:                                          5.00
+      Accrued financing during construction:                  0.00
+      Project lifetime:                                      30 yr
+      Capacity factor:                                       80.0 %
+      Project NPV:                                         -43.70 MUSD
+      Project IRR:                                          -0.05 %
+      Project VIR=PI=PIR:                                    0.23
+      Project MOIC:                                         -0.20
+
+                          ***ENGINEERING PARAMETERS***
+
+      Number of Production Wells:                             2
+      Number of Injection Wells:                              2
+      Well depth (or total length, if not vertical):          4.0 kilometer
+      Water loss rate:                                        0.0
+      Pump efficiency:                                       80.0
+      Injection temperature:                                 50.0 degC
+      User-provided production well temperature drop
+      Constant production well temperature drop:              3.0 degC
+      Flowrate per production well:                          50.0 kg/sec
+      Injection well casing ID:                               0.004 meter
+      Production well casing ID:                              0.004 meter
+      Number of times redrilling:                             1
+      Power plant type:                                       Subcritical ORC
+
+
+                         ***RESOURCE CHARACTERISTICS***
+
+      Maximum reservoir temperature:                        400.0 degC
+      Number of segments:                                     1
+      Geothermal gradient:                                    0.0500 degC/m
+
+
+                           ***RESERVOIR PARAMETERS***
+
+      Reservoir Model = Annual Percentage Thermal Drawdown Model
+      Annual Thermal Drawdown:                                1.000 1/year
+      Bottom-hole temperature:                              212.00 degC
+      Warning: the reservoir dimensions and thermo-physical properties
+               listed below are default values if not provided by the user.
+               They are only used for calculating remaining heat content.
+      Reservoir volume provided as input
+      Reservoir volume:                               125000000 m**3
+      Reservoir hydrostatic pressure:                       100.00 kPa
+      Plant outlet pressure:                               2261.62 kPa
+      Production wellhead pressure:                        2330.57 kPa
+      Productivity Index:                                    10.00 kg/sec/bar
+      Injectivity Index:                                     10.00 kg/sec/bar
+      Reservoir density:                                   2700.00 kg/m**3
+      Reservoir heat capacity:                             1000.00 J/kg/kelvin
+
+
+                           ***RESERVOIR SIMULATION RESULTS***
+
+      Maximum Production Temperature:                       209.0 degC
+      Average Production Temperature:                       197.0 degC
+      Minimum Production Temperature:                       184.2 degC
+      Initial Production Temperature:                       209.0 degC
+      Average Reservoir Heat Extraction:                     62.49 MW
+      Wellbore Heat Transmission Model = Constant Temperature Drop:       3.0 degC
+      Average Injection Well Pump Pressure Drop:          -1407.4 kPa
+      Average Production Well Pump Pressure Drop:          1636.3 kPa
+
+
+                          ***CAPITAL COSTS (M$)***
+
+         Drilling and completion costs:                      33.28 MUSD
+         Drilling and completion costs per well:              8.32 MUSD
+         Stimulation costs:                                   1.00 MUSD
+         Surface power plant costs:                          20.07 MUSD
+         Field gathering system costs:                        2.32 MUSD
+         Total surface equipment costs:                      22.39 MUSD
+         Exploration costs:                                   0.00 MUSD
+      Total capital costs:                                   56.67 MUSD
+
+
+                ***OPERATING AND MAINTENANCE COSTS (M$/yr)***
+
+         Wellfield maintenance costs:                         0.69 MUSD/yr
+         Power plant maintenance costs:                       1.32 MUSD/yr
+         Water costs:                                         0.00 MUSD/yr
+      Total operating and maintenance costs:                  3.15 MUSD/yr
+
+
+                           ***SURFACE EQUIPMENT SIMULATION RESULTS***
+
+      Initial geofluid availability:                          0.11 MW/(kg/s)
+      Maximum Total Electricity Generation:                   3.40 MW
+      Average Total Electricity Generation:                   3.40 MW
+      Minimum Total Electricity Generation:                   3.40 MW
+      Initial Total Electricity Generation:                   3.40 MW
+      Maximum Net Electricity Generation:                     3.24 MW
+      Average Net Electricity Generation:                     3.16 MW
+      Minimum Net Electricity Generation:                     3.09 MW
+      Initial Net Electricity Generation:                     3.24 MW
+      Average Annual Total Electricity Generation:           23.84 GWh
+      Average Annual Net Electricity Generation:             22.18 GWh
+      Initial pumping power/net installed power:            100.00 %
+      Maximum Net Heat Production:                           20.07 MW
+      Average Net Heat Production:                           15.98 MW
+      Minimum Net Heat Production:                           11.62 MW
+      Initial Net Heat Production:                           20.07 MW
+      Average Annual Heat Production:                       111.95 GWh
+      Average Pumping Power:                                  0.24 MW
+
+                            ************************************************************
+                            *  HEATING, COOLING AND/OR ELECTRICITY PRODUCTION PROFILE  *
+                            ************************************************************
+  YEAR     THERMAL             GEOFLUID             PUMP             NET              NET             FIRST LAW
+           DRAWDOWN           TEMPERATURE           POWER           POWER             HEAT            EFFICIENCY
+                                (deg C)             (MW)            (MW)              (MW)               (%)
+   0         1.0000              209.00             0.1589          3.2429             20.0682               7.6272
+   1         0.9922              207.38             0.1699          3.2318             19.5172               7.6011
+   2         0.9845              205.76             0.1809          3.2208             18.9661               7.5754
+   3         0.9767              204.14             0.1917          3.2100             18.4151               7.5499
+   4         0.9690              202.52             0.2024          3.1993             17.8641               7.5247
+   5         0.9612              200.90             0.2130          3.1887             17.3131               7.4999
+   6         0.9535              199.28             0.2234          3.1783             16.7620               7.4753
+   7         0.9457              197.66             0.2338          3.1680             16.2110               7.4510
+   8         0.9380              196.04             0.2440          3.1578             15.6600               7.4270
+   9         0.9302              194.42             0.2540          3.1477             15.1090               7.4033
+  10         0.9225              192.80             0.2640          3.1377             14.5579               7.3799
+  11         0.9147              191.18             0.2739          3.1279             14.0069               7.3567
+  12         0.9070              189.56             0.2836          3.1182             13.4559               7.3339
+  13         0.8992              187.94             0.2932          3.1086             12.9049               7.3113
+  14         0.8915              186.32             0.3027          3.0991             12.3538               7.2889
+  15         0.8837              184.70             0.3121          3.0897             11.8028               7.2669
+  16         0.9974              208.46             0.1626          3.2392             19.8845               7.6185
+  17         0.9897              206.84             0.1736          3.2281             19.3335               7.5925
+  18         0.9819              205.22             0.1845          3.2172             18.7825               7.5668
+  19         0.9742              203.60             0.1953          3.2064             18.2314               7.5415
+  20         0.9664              201.98             0.2060          3.1958             17.6804               7.5164
+  21         0.9587              200.36             0.2165          3.1852             17.1294               7.4916
+  22         0.9509              198.74             0.2269          3.1748             16.5784               7.4672
+  23         0.9432              197.12             0.2372          3.1646             16.0273               7.4430
+  24         0.9354              195.50             0.2473          3.1544             15.4763               7.4191
+  25         0.9277              193.88             0.2574          3.1444             14.9253               7.3955
+  26         0.9199              192.26             0.2673          3.1344             14.3743               7.3721
+  27         0.9122              190.64             0.2771          3.1246             13.8232               7.3491
+  28         0.9044              189.02             0.2868          3.1149             13.2722               7.3263
+  29         0.8967              187.40             0.2964          3.1054             12.7212               7.3038
+
+
+                              *******************************************************************
+                              *  ANNUAL HEATING, COOLING AND/OR ELECTRICITY PRODUCTION PROFILE  *
+                              *******************************************************************
+  YEAR             HEAT                 ELECTRICITY                HEAT              RESERVOIR        PERCENTAGE OF
+                  PROVIDED               PROVIDED                EXTRACTED          HEAT CONTENT    TOTAL HEAT MINED
+                 (GWh/year)             (GWh/year)               (GWh/year)          (10^15 J)           (%)
+   1               138.7                   22.7                    471.35               52.98                 3.10
+   2               134.8                   22.6                    466.52               51.30                 6.18
+   3               131.0                   22.5                    461.69               49.64                 9.22
+   4               127.1                   22.5                    456.86               47.99                12.22
+   5               123.3                   22.4                    452.04               46.36                15.20
+   6               119.4                   22.3                    447.21               44.75                18.14
+   7               115.5                   22.2                    442.38               43.16                21.06
+   8               111.7                   22.2                    437.56               41.59                23.94
+   9               107.8                   22.1                    432.73               40.03                26.79
+  10               104.0                   22.0                    427.90               38.49                29.60
+  11               100.1                   22.0                    423.08               36.97                32.39
+  12                96.2                   21.9                    418.25               35.46                35.14
+  13                92.4                   21.8                    413.42               33.97                37.87
+  14                88.5                   21.8                    408.59               32.50                40.56
+  15                84.6                   21.7                    403.77               31.05                43.22
+  16               111.0                   22.2                    436.75               29.47                46.09
+  17               137.4                   22.7                    469.74               27.78                49.18
+  18               133.6                   22.6                    464.91               26.11                52.25
+  19               129.7                   22.5                    460.08               24.45                55.27
+  20               125.8                   22.4                    455.26               22.81                58.27
+  21               122.0                   22.4                    450.43               21.19                61.24
+  22               118.1                   22.3                    445.60               19.59                64.17
+  23               114.3                   22.2                    440.77               18.00                67.07
+  24               110.4                   22.1                    435.95               16.43                69.94
+  25               106.5                   22.1                    431.12               14.88                72.78
+  26               102.7                   22.0                    426.29               13.35                75.59
+  27                98.8                   21.9                    421.47               11.83                78.37
+  28                94.9                   21.9                    416.64               10.33                81.11
+  29                91.1                   21.8                    411.81                8.85                83.82
+  30                87.2                   21.7                    406.99                7.38                86.50

--- a/tests/examples/example13.txt
+++ b/tests/examples/example13.txt
@@ -1,0 +1,75 @@
+----------------------------------------------------------------------------------------
+GEOPHIRES v3.0 Input File
+Example 13
+This example file tests redrilling due to excessive drawdown and use of cogen bottoming cycle as end-use
+Created by Koenraad Beckers on 11/20/2023
+----------------------------------------------------------------------------------------
+
+*** Subsurface technical parameters ***
+****************************************
+Reservoir Model,4,			--- Percentage thermal drawdown model
+Drawdown Parameter,0.01, 		--- In [1/year].
+Reservoir Depth,4, 			--- [km]
+Number of Segments,1,			--- [-]
+Gradient 1,50, 				--- [deg.C/km]
+Number of Production Wells,2,		--- [-]
+Number of Injection Wells,2,		--- [-]
+Production Well Diameter,6,		--- [inch]
+Injection Well Diameter,6,		--- [inch]
+Ramey Production Wellbore Model,0,	--- Should be 0 (disable) or 1 (enable)
+Production Wellbore Temperature Drop,3,	--- [deg.C]
+Injection Wellbore Temperature Gain,0,	--- [deg.C]
+Production Flow Rate per Well,50, 	--- [kg/s]
+Maximum Temperature,400,		--- [deg.C]
+Reservoir Volume Option,4,		--- Should be 1, 2, 3, or 4. See manual for details.
+Reservoir Volume,1.25e8,		--- [m3] (required for reservoir volume option 3 and 4
+Water Loss Fraction,0.0,		--- [-] (total geofluid lost)/(total geofluid produced)
+Injectivity Index,10,			--- [kg/s/bar]
+Productivity Index,10,			--- [kg/s/bar]
+Injection Temperature,50,		--- [deg.C]
+Maximum Drawdown,0.12,			--- [-] Maximum allowable drawdown before redrilling (a value of 0.1 means redrilling of 10% drawdown)
+Reservoir Heat Capacity,1000,		--- [J/kg/K]
+Reservoir Density,2700,			--- [kg/m3]
+Reservoir Thermal Conductivity,3,	--- [W/m/K]
+
+
+*** Surface technical parameters ***
+************************************
+End-Use Option,42,			--- [-] Co-gen bottoming cycle with heat the main product
+Circulation Pump Efficiency,0.8,	--- [-]
+Utilization Factor,0.8,			--- [-]
+Surface Temperature,12,			--- [deg.C]
+Ambient Temperature,12,			--- [deg.C]
+End-Use Efficiency Factor,0.8,		--- [-]
+
+District Heating Demand Option,1,					--- Should be 1 or 2. See manual or below for option details
+District Heating Demand File Name,Examples/cornell_heat_demand.csv,		--- hourly MW thermal demand in a CSV file
+District Heating Demand Data Time Resolution,1,				--- 1 for hourly, 2 for daily
+District Heating Demand Data Column Number,2,				---
+
+Peaking Fuel Cost Rate,0.0273, 					--- [$/kWh] Cost of natural gas for peak boiler use
+Peaking Boiler Efficiency,0.85,			`		--- Should be between 0 and 1, defaults to 0.85
+District Heating Piping Cost Rate,1200,					--- [$/m] used for calculating surface piping capital cost for district heat
+District Heating Road Length,3, 				---[km] supersedes model option 2 if any value is entered
+
+
+*** Economic/Financial Parameters ***
+*************************************
+Plant Lifetime,30,						--- [years]
+Economic Model,2,						--- Should be 1 (FCR model), 2 (Standard LCOE/LCOH model), or 3 (Bicycle model).
+Discount Rate,0.05,
+Inflation Rate During Construction,0,				--- [-]
+Well Drilling and Completion Capital Cost Adjustment Factor,1,	--- [-] Use built-in well cost correlation as is
+Well Drilling Cost Correlation,1,				--- [-] Use built-in well drilling cost correlation #1
+Reservoir Stimulation Capital Cost,1,				--- [M$/injection well] Reservoir stimulation capital cost per injection well
+Surface Plant Capital Cost Adjustment Factor,1,			--- [-] Use built-in surface plant cost correlation as is
+Field Gathering System Capital Cost Adjustment Factor,1,	--- [-] Use built-in pipeline distribution cost correlation as is
+Exploration Capital Cost Adjustment Factor,0,			--- [-] Use built-in exploration cost correlation as is
+Wellfield O&M Cost Adjustment Factor,1,				--- [-] Use built-in wellfield O&M cost correlation as is
+Water Cost Adjustment Factor,1,					--- [-] Use built-in water cost correlation as is
+Surface Plant O&M Cost Adjustment Factor,1,			--- [-] Use built-in surface plant O&M cost correlation as is
+
+
+*** Simulation Parameters ***
+Print Output to Console,1,		--- [-] Should be 0 (don't print results to console) or 1 (print results to console)
+Time steps per year,3,			--- [1/year]

--- a/tests/examples/example9.txt
+++ b/tests/examples/example9.txt
@@ -17,43 +17,43 @@ Gradient 1,28,                          	---[deg.C/km]
 Maximum Temperature,400,                  	---[deg.C]
 Number of Production Wells,1,            	---[-]
 Number of Injection Wells,1,            	---[-]
-Production Well Diameter,7,		     		---[inch]
-Injection Well Diameter,7,					---[inch]
+Production Well Diameter,7,		     	---[inch]
+Injection Well Diameter,7,			---[inch]
 Ramey Production Wellbore Model,1,       	---0 if disabled 1 if enabled
 Injection Wellbore Temperature Gain,0,		---[deg.C]
 Production Flow Rate per Well,40,       	---[kg/s]
 Fracture Shape,3,                       	---[-] Should be 1 2 3 or 4. See manual for details
-Fracture Height,700, 						---[m]
+Fracture Height,700, 				---[m]
 Reservoir Volume Option,1,              	---[-] Should be 1 2 3 or 4. See manual for details
-Number of Fractures,5,		  				---[-]
-Fracture Separation,100,					---[m]
-Reservoir Impedance,0.05,					---[GPa*s/m3]
-Water Loss Fraction,.02,					---[-]
-Productivity Index,5,						---[kg/s/bar]
-Injectivity Index,5,						---[kg/s/bar]
-Injection Temperature,60,		 			---[deg.C]
-Maximum Drawdown,1,			  				---[-] no redrilling considered
-Reservoir Heat Capacity,825,		  		---[J/kg/K]
-Reservoir Density,2730,			  			---[kg/m^3]
+Number of Fractures,5,		  		---[-]
+Fracture Separation,100,			---[m]
+Reservoir Impedance,0.05,			---[GPa*s/m3]
+Water Loss Fraction,.02,			---[-]
+Productivity Index,5,				---[kg/s/bar]
+Injectivity Index,5,				---[kg/s/bar]
+Injection Temperature,60,		 	---[deg.C]
+Maximum Drawdown,1,			  	---[-] no redrilling considered
+Reservoir Heat Capacity,825,		  	---[J/kg/K]
+Reservoir Density,2730,			  	---[kg/m^3]
 Reservoir Thermal Conductivity,2.83,	  	---[W/m/K]
 
 ***SURFACE TECHNICAL PARAMETERS***
 **********************************
-End-Use Option,1,			  				---[-] Direct-Use
-Power Plant Type, 1,						---[-] Subcritical ORC
-Circulation Pump Efficiency,.8,	  			---[-]
-Utilization Factor,.9,			  			---[-]
-End-Use Efficiency Factor,0.9,				---[-]
-Surface Temperature,20,		  				---[deg.C]
-Ambient Temperature,20,		 				---[deg.C]
-Electricity Rate,0.1,						---Electricity rate for pumping power [$/kWh]
+End-Use Option,1,			  	---[-] Electricity
+Power Plant Type, 1,				---[-] Subcritical ORC
+Circulation Pump Efficiency,.8,	  		---[-]
+Utilization Factor,.9,			  	---[-]
+End-Use Efficiency Factor,0.9,			---[-]
+Surface Temperature,20,		  		---[deg.C]
+Ambient Temperature,20,		 		---[deg.C]
+Electricity Rate,0.1,				---Electricity rate for pumping power [$/kWh]
 
 ***FINANCIAL PARAMETERS***
 **************************
-Plant Lifetime,30,			  			---[years]
-Economic Model,1,			  			---[-] Fixed Charge Rate Model
-Fixed Charge Rate,.05,			 			---[-] between 0 and 1
-Inflation Rate During Construction,0,   			---[-]
+Plant Lifetime,30,			  	---[years]
+Economic Model,1,			  	---[-] Fixed Charge Rate Model
+Fixed Charge Rate,.05,			 	---[-] between 0 and 1
+Inflation Rate During Construction,0,   	---[-]
 
 ***CAPITAL AND O&M COST PARAMETERS***
 *************************************


### PR DESCRIPTION
New unit test (example 13.txt):
- simulates well redrilling after excessive drawdown (address issue https://github.com/NREL/python-geophires-x/issues/39)
- has 42 as end-use option (co-gen bottoming cycle) to further increase coverage as no other unit test had this end-use option.

Simulating co-gen bottom cycle as end-use revealed a few bugs that are now fixed.